### PR TITLE
Deprecate MF Blocks TablePress Block

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -169,3 +169,45 @@ function mbg4_allow_aria_attributes( $tags, $context ) {
 	return $tags;
 }
 add_filter( 'wp_kses_allowed_html', 'mbg4_allow_aria_attributes', 10, 2 );
+
+// Make the `tablepress_tables option available via REST api to allow table lookup by post ID
+add_action( 'rest_api_init', function () {
+	register_rest_route( 'mayflower-blocks/v1', '/tableid-by-postid/(?P<id>\d+)', array(
+		'methods' => 'GET',
+		'callback' => 'mbg4_table_callback',
+		'args' => array(
+			'id' => array(
+				'required' => true,
+				'type' => 'integer',
+			),
+		),
+
+
+		'permission_callback' => function () {
+			return current_user_can( 'edit_posts' );
+		}
+	) );
+} );
+
+/**
+ * Callback function for retrieving a TablePress table ID by post ID via REST API.
+ *
+ * @param array $request The REST API request data, should contain 'postid'.
+ * @return mixed The TablePress table ID corresponding to the given post ID, or null if not found.
+ */
+function mbg4_table_callback( $request  ) {
+	$id = $request['id'];
+	if ( ! $id ) {
+		return null;
+	}
+
+	$table_option = json_decode( get_option( 'tablepress_tables' ) );
+	foreach ( $table_option->table_post as $key => $value ) {
+		if ( $value == $id ) {
+			return array( 'tableId' => $key );
+		}
+	}
+
+	return array( 'tableId' => false );
+
+}

--- a/src/tablepress/block.json
+++ b/src/tablepress/block.json
@@ -2,13 +2,14 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "mayflower-blocks/tablepress",
-	"version": "1.0.1",
-	"title": "TablePress",
+	"version": "2.0.0",
+	"title": "TablePress (legacy)",
 	"category": "common",
 	"icon": "media-spreadsheet",
-	"description": "Insert a Table created in TablePress. Note: This block was created by Bellevue College, and is not officially affiliated with TablePress!",
+	"description": "Insert a Table created in TablePress. Note: This block was created by Bellevue College, and is not officially affiliated with TablePress! This block is no longer recommended, as there is a native TablePress block available.",
 	"supports": {
-		"html": false
+		"html": false,
+		"inserter": false
 	},
 	"textdomain": "mayflower-blocks",
 	"attributes": {

--- a/src/tablepress/edit.js
+++ b/src/tablepress/edit.js
@@ -61,7 +61,14 @@ export default function Edit( props ) {
 		return tableArray;
 	});
 
-
+	// Set Table ID if it's missing
+	if ( ! tableId ) {
+		apiFetch( { path: '/mayflower-blocks/v1/tableid-by-postid/' + postId } ).then( result => {
+			if ( result.tableId ) {
+				setAttributes( { tableId: result.tableId } );
+			}
+		} );
+	}
 
 	const TableError = () => {
 		if ( ! tableFetched ) {
@@ -104,7 +111,7 @@ export default function Edit( props ) {
 
 		// If this table was converted from a shortcode `tableId` is set but not `postId`.
 		// Display a different interface to select the table.
-		if ( tableId && false === select ) {
+		if ( ! postId && false === select ) {
 			return (
 				<ToolbarButton
 					onClick={ () => setSelect( true ) }
@@ -115,7 +122,7 @@ export default function Edit( props ) {
 
 
 		// Checks to make sure a tableId isn't defined or the user doesn't want to select a new table
-		if ( ( tableId === undefined || tableId === '' ) || select === true ) {
+		if ( ! ( postId === undefined || postId === '' ) || select === true ) {
 			return (
 				<ToolbarGroup>
 					<ToolbarButton

--- a/src/tablepress/transforms.js
+++ b/src/tablepress/transforms.js
@@ -1,3 +1,4 @@
+import { createBlock } from '@wordpress/blocks';
 const transforms = {
 	from: [
 		{
@@ -11,6 +12,25 @@ const transforms = {
 					},
 				},
 			},
+		},
+	],
+
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'tablepress/table' ],
+			transform: ( attributes ) => {
+				// If there is a table ID available, use it
+				if ( attributes.tableId ) {
+					console.log( 'Found table ID in attributes - creating tablepress/table block' );
+					return createBlock(
+						'tablepress/table',
+						{ id: attributes.tableId },
+					);
+				}
+			}
+
+
 		},
 	],
 };


### PR DESCRIPTION
The Mayflower Blocks TablePress Block is no longer needed, as TablePress now provides one!

This PR adds functionality to allow transformations of the legacy block into the official block, hides the legacy block from the editor, and changes naming of the legacy block.