### PR TITLE
🐛 FIX: Card Image Selection

### DIFF
--- a/src/panel/block.json
+++ b/src/panel/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "mayflower-blocks/panel",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"title": "Card (Panel)",
 	"category": "bootstrap-blocks",
 	"icon": "align-center",

--- a/src/panel/edit.js
+++ b/src/panel/edit.js
@@ -93,7 +93,7 @@ export default function Edit( props ) {
 							onSelect={ ( value ) => {
 								setAttributes( {
 									cardImageId: value.id,
-									cardImageUrl: value.sizes[ cardImageSize ].url,
+									cardImageUrl: (value.sizes && value.sizes[cardImageSize]?.url) || value.url,
 									cardImageAlt: value.alt,
 								} );
 								onClose();
@@ -182,7 +182,7 @@ export default function Edit( props ) {
 										value={ cardImageId }
 										onSelect={ ( value ) => setAttributes( {
 											cardImageId: value.id,
-											cardImageUrl: value.sizes[ cardImageSize ].url,
+											cardImageUrl: (value.sizes && value.sizes[cardImageSize]?.url) || value.url,
 											cardImageAlt: value.alt,
 										} ) }
 										render= { ( { open } ) => (


### PR DESCRIPTION
Fix Card (Panel) WP-Admin: Card Image can fail Image selection if size is too small #83