### PR TITLE
Add Anchor Support to Appropriate Blocks

### DIFF
--- a/src/collapse/block.json
+++ b/src/collapse/block.json
@@ -2,13 +2,14 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "mayflower-blocks/collapse",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"title": "Collapse",
 	"category": "bootstrap-blocks",
 	"icon": "block-default",
 	"description": "Individual collapse element inside an Accordion block.",
 	"supports": {
-		"html": false
+		"html": false,
+		"anchor": true
 	},
 	"parent":[
 		"mayflower-blocks/collapsibles"

--- a/src/panel/block.json
+++ b/src/panel/block.json
@@ -2,14 +2,15 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "mayflower-blocks/panel",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"title": "Card (Panel)",
 	"category": "bootstrap-blocks",
 	"icon": "align-center",
 	"description": "The card block allows content to be displayed in a card format, optionally with a header and footer.",
 	"supports": {
 		"html": true,
-		"align": ["wide"]
+		"align": ["wide"],
+		"anchor": true
 	},
 	"textdomain": "mayflower-blocks",
 	"attributes": {

--- a/src/tabs/block.json
+++ b/src/tabs/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "mayflower-blocks/tabs",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"title": "Tabs",
 	"category": "bootstrap-blocks",
 	"icon": "category",
@@ -10,7 +10,8 @@
 	"supports": {
 		"html": false,
 		"lock": false,
-		"align": ["wide"]
+		"align": ["wide"],
+		"anchor": true
 	},
 	"textdomain": "mayflower-blocks",
 	"attributes": {},


### PR DESCRIPTION
- Added support in Mayflower Blocks-> Card.
- Support CAN NOT be added to Mayflower Blocks-> Accordion due to element already having an auto-generated ID.
- Added support for Mayflower Blocks -> Collapse (each element inside an accordion). Note that targeting one will NOT cause it to open.
- Added support to legacy Mayflower Blocks -> Tabs. This doesn't apply to tabs in Sitka, but does in Douglas Fir and Bellevue 2022. This allows for scrolling to the tab area as a whole, not selecting a specific tab.

This is related to https://github.com/BellevueCollege/bc-sitka-spruce-department-theme/issues/340