### PR TITLE
Editoria11y support

### DIFF
--- a/src/collapse/block.json
+++ b/src/collapse/block.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "mayflower-blocks/collapse",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"title": "Collapse",
 	"category": "bootstrap-blocks",
 	"icon": "block-default",

--- a/src/collapse/edit.js
+++ b/src/collapse/edit.js
@@ -10,6 +10,7 @@ import {
 	Toolbar,
 	ToolbarDropdownMenu,
 	ToolbarButton,
+	Button,
 	SVG,
 	Path,
 	G,
@@ -26,7 +27,8 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 
-import {select,} from '@wordpress/data';
+import { select } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 
 import {
 	ToolbarBootstrapColorSelector,
@@ -57,6 +59,47 @@ export default function Edit( props ) {
 	setAttributes( { currentBlockClientId: clientId } );
 	setAttributes( { parentBlockClientId: parentClientId } );
 
+	// Local state to track editor display only (not saved to database)
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	/**
+	 * Handle accordion behavior: close siblings when one opens
+	 */
+	useEffect( () => {
+		const handleCollapseToggle = ( event ) => {
+			const { collapseId, parentId } = event.detail;
+
+			// If another collapse in same parent opened, close this one
+			if ( parentId === parentClientId && collapseId !== clientId ) {
+				setIsOpen( false );
+			}
+		};
+
+		window.addEventListener( 'mayflower-collapse-toggle', handleCollapseToggle );
+
+		return () => {
+			window.removeEventListener( 'mayflower-collapse-toggle', handleCollapseToggle );
+		};
+	}, [ parentClientId, clientId ] );
+
+	/**
+	 * Toggle accordion open/closed state
+	 */
+	const toggleAccordion = () => {
+		setIsOpen( ! isOpen );
+
+		// Notify siblings to close
+		const event = new CustomEvent( 'mayflower-collapse-toggle', {
+			detail: { collapseId: clientId, parentId: parentClientId }
+		} );
+		window.dispatchEvent( event );
+	};
+
+	useEffect( () => {
+		if ( isSelected && ! isOpen ) {
+			toggleAccordion();
+		}
+	}, [ isSelected ] );
 
 	const colorClass = `bg-${ collapseClass } text-bg-${ collapseClass }
 		${ collapseClass !== 'default' && collapseClass !== 'light' && collapseClass !== 'warning' && collapseClass !== 'info' ? ' text-white' : '' }`;
@@ -76,22 +119,35 @@ export default function Edit( props ) {
 
 	const HeadingTag = headingTag;
 
+	const openIcon = (
+		<>
+			{ __( 'Expand +', 'mayflower-blocks') }
+		</>
+	);
+
+	const closeIcon = (
+		<>
+			{ __( 'Collapse –', 'mayflower-blocks') }
+		</>
+	);
+
 	/**
 	 * Check if ANY child block is currently selected
 	 *
 	 * Credit: https://stackoverflow.com/a/55955285
 	 */
-	function hasSelectedChild(props) {
-		const select = wp.data.select('core/block-editor');
+	function hasSelectedChild( props ) {
+		const select = wp.data.select( 'core/block-editor' );
 		const selected = select.getBlockSelectionStart();
-		const inner = select.getBlock(props.clientId).innerBlocks;
-		for (let i = 0; i < inner.length; i++) {
-			if (inner[i].clientId === selected || inner[i].innerBlocks.length && hasSelectedChild(inner[i])) {
+		const inner = select.getBlock( props.clientId ).innerBlocks;
+		for ( let i = 0; i < inner.length; i++ ) {
+			if ( inner[ i ].clientId === selected || inner[ i ].innerBlocks.length && hasSelectedChild( inner[ i ] ) ) {
 				return true;
 			}
 		}
 		return false;
-	};
+	}
+
 	return (
 		<>
 			<BlockControls>
@@ -168,7 +224,7 @@ export default function Edit( props ) {
 				<>
 					{ isBootstrap5 ? (
 						<HeadingTag className={ `${blockClasses.heading }` } id={ `heading_${ currentBlockClientId }` }>
-							<div className={ `${ blockClasses.headingButton } ${ isSelected ? 'active' : 'collapsed' }` } >
+							<div className={ `${ blockClasses.headingButton } ${ isOpen ? 'active' : 'collapsed' }` } >
 								<RichText
 									tagName="span"
 									allowedFormats= { [] }
@@ -182,6 +238,13 @@ export default function Edit( props ) {
 								>
 									<span className="badge bg-secondary ms-2">{ headingTag.toUpperCase() }</span>
 								</Tooltip>
+								<Button
+									onClick={ toggleAccordion }
+									className="accordion-editor-toggle"
+									variant="primary"
+								>
+									{ isOpen ? closeIcon : openIcon }
+								</Button>
 							</div>
 						</HeadingTag>
 					) : (
@@ -200,13 +263,20 @@ export default function Edit( props ) {
 								>
 									<span className="badge badge-info float-right">{ headingTag.toUpperCase() }</span>
 								</Tooltip>
+								<Button
+									onClick={ toggleAccordion }
+									className="accordion-editor-toggle"
+									variant="primary"
+								>
+									{ isOpen ? closeIcon : openIcon }
+								</Button>
 							</HeadingTag>
 						</div>
 					) }
 				</>
 				<div
 					id={ `collapse_${ currentBlockClientId }` }
-					className={ `${ blockClasses.collapse } ${ expanded || isSelected || hasSelectedChild( props ) ? 'show' : '' }` }
+					className={ `${ blockClasses.collapse } ${ isOpen || hasSelectedChild( props ) ? 'show' : '' }` }
 					aria-labelledby={ `heading_${ currentBlockClientId }` }
 					data-parent={ `#accordion_${ parentClientId }` }
 				>

--- a/src/collapse/editor.scss
+++ b/src/collapse/editor.scss
@@ -5,15 +5,31 @@
  * which makes it higher in priority.
  */
 
-.wp-block-mayflower-blocks-collapse{
+.wp-block-mayflower-blocks-collapse {
+	margin: 0;
+	&.card {
+		padding: 0;
+		max-width: 100%;
 		margin: 0;
-        &.card {
-            padding: 0;
-			max-width: 100%;
-			margin: 0;
-			margin-bottom: 0 !important;
-        }
-        .card-body > *:last-child {
-			margin-bottom: 0;
-        }
-    }
+		margin-bottom: 0 !important;
+	}
+	.card-body > *:last-child {
+		margin-bottom: 0;
+	}
+
+	.accordion-button:after {
+		display: none;
+	}
+
+	.accordion-button, .card-header .h6 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.accordion-editor-toggle {
+		order: 999; // Forces it to display last
+		margin-left: auto; // Pushes it to the right
+	}
+}
+

--- a/src/collapsibles/block.json
+++ b/src/collapsibles/block.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "mayflower-blocks/collapsibles",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"title": "Accordion (Collapsibles)",
 	"category": "bootstrap-blocks",
 	"icon": "editor-contract",
@@ -46,6 +46,7 @@
 		]
 	},
 	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"
 }

--- a/src/collapsibles/edit.js
+++ b/src/collapsibles/edit.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 import { useSelect, select, dispatch } from '@wordpress/data';
 
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 import {
 	Spinner
@@ -38,7 +38,25 @@ export default function Edit( props ) {
 	const { attributes: {
 		currentBlockClientId,
 	}, setAttributes, isSelected, clientId } = props;
+
+	// Editor-only state - NOT saved
+	const [openCollapseId, setOpenCollapseId] = useState(null);
+
 	setAttributes( { currentBlockClientId: clientId } );
+
+	// Listen for custom events from children
+	useEffect(() => {
+		const handleCollapseToggle = (event) => {
+			const { collapseId } = event.detail;
+			setOpenCollapseId(prevId => prevId === collapseId ? null : collapseId);
+		};
+
+		window.addEventListener('mayflower-collapse-toggle', handleCollapseToggle);
+
+		return () => {
+			window.removeEventListener('mayflower-collapse-toggle', handleCollapseToggle);
+		};
+	}, []);
 
 	const blockProps = useBlockProps({
 		className: 'accordion',

--- a/src/collapsibles/view.js
+++ b/src/collapsibles/view.js
@@ -1,0 +1,25 @@
+document.addEventListener('ed11yPanelOpened', e => {
+	// get elements inside a <ed11y-element-result> tag
+	let elements = document.querySelectorAll('ed11y-element-result');
+
+	// Loop through elements and find the closest `.accordion-collapse` element
+	elements.forEach((element) => {
+		let collapse = element.closest('.accordion-collapse');
+
+		// fallback for Bootstrap 4
+		if ( ! collapse ) {
+			collapse = element.closest('.collapse');
+		}
+
+		if ( collapse ) {
+			// Add 'show' class to the collapse element
+			collapse.classList.add('show');
+
+			// Set aria expanded to true on the header and remove collapsed class
+			let headerId = collapse.getAttribute('aria-labelledby');
+			let header = document.getElementById( headerId ).firstChild;
+			header.setAttribute('aria-expanded', 'true' );
+			header.classList.remove('collapsed');
+		}
+	});
+});


### PR DESCRIPTION

- Automatically open Accordions on the front end if there is an active Editoria11y error within them.
- mprove expand/collapse handling in the editor to make errors readable

**Note:** This was already reviewed and approved previously- needed to recreate due to wrong release branch issue. 

