### PR TITLE
🐛 FIX: Tab Inserter Icon in iFramed Editor

### DIFF
--- a/src/tab-list/edit.js
+++ b/src/tab-list/edit.js
@@ -11,8 +11,7 @@ import { createBlock } from '@wordpress/blocks';
 
 
 import {
-	Button,
-	Dashicon
+	Button
 } from '@wordpress/components';
 
 import {
@@ -99,8 +98,8 @@ export default function Edit( props ) {
 			/>
 			<li role="presentation">
 				<Button onClick={ addTab } className="add-tab">
-					<Dashicon icon="insert" />
-					{ currentBlockData.innerBlocks.length === 0 ? <span>Add Tab</span> : '' }
+					<i className='fas fa-plus fa-solid add-tab-icon'></i>
+					{ currentBlockData.innerBlocks.length === 0 ? <span>Add Tab</span> : <span className='screen-reader-text'>Add Tab</span> }
 				</Button>
 			</li>
 		</ul>

--- a/src/tabs/editor.scss
+++ b/src/tabs/editor.scss
@@ -11,6 +11,7 @@
 	border-radius: 5px;
 }
 
+
 /**
 * Tab List
 */
@@ -28,23 +29,17 @@
 		border: 1px solid transparent;
 
 		button.add-tab {
-			padding: 10px 15px;
-			color: #555555;
-			border-radius: 4px 4px 0 0;
+			padding: 10px 5px;
+			color: #222;
+			border-radius: var(--bs-border-radius, 5px);
 			align-items: center;
-			&:hover {
-				border: 1px solid #ddd;
-				border-bottom-color: transparent;
-				margin: -1px;
+			background-color: var(--white, #fff);
+			border: 2px solid var(--gray--light, #ccc);
+
+			&:hover, &:focus {
+				border: 2px solid var(--gray--medium, #999);
 			}
 
-			span {
-				margin-left: 10px;
-			}
-
-			span.dashicon {
-				margin-left: 0px;
-			}
 		}
 
 		a {


### PR DESCRIPTION
Improve contrast and accessibility of icon, and move to FontAwesome for more reliable display